### PR TITLE
Fix async reserved keyword (python 3.7)

### DIFF
--- a/sib_api_v3_sdk/api/account_api.py
+++ b/sib_api_v3_sdk/api/account_api.py
@@ -37,17 +37,17 @@ class AccountApi(object):
         """Get your account informations, plans and credits details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_account(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_account(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_account_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_account_with_http_info(**kwargs)  # noqa: E501
@@ -57,18 +57,18 @@ class AccountApi(object):
         """Get your account informations, plans and credits details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_account_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_account_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAccount
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class AccountApi(object):
             files=local_var_files,
             response_type='GetAccount',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/attributes_api.py
+++ b/sib_api_v3_sdk/api/attributes_api.py
@@ -37,11 +37,11 @@ class AttributesApi(object):
         """Creates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_attribute(attribute_category, attribute_name, create_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_attribute(attribute_category, attribute_name, create_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the attribute (required)
         :param CreateAttribute create_attribute: Values to create an attribute (required)
@@ -50,7 +50,7 @@ class AttributesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, **kwargs)  # noqa: E501
         else:
             (data) = self.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class AttributesApi(object):
         """Creates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the attribute (required)
         :param CreateAttribute create_attribute: Values to create an attribute (required)
@@ -74,7 +74,7 @@ class AttributesApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name', 'create_attribute']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -140,7 +140,7 @@ class AttributesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -150,11 +150,11 @@ class AttributesApi(object):
         """Deletes an attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_attribute(attribute_category, attribute_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_attribute(attribute_category, attribute_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :return: None
@@ -162,7 +162,7 @@ class AttributesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_attribute_with_http_info(attribute_category, attribute_name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_attribute_with_http_info(attribute_category, attribute_name, **kwargs)  # noqa: E501
@@ -172,11 +172,11 @@ class AttributesApi(object):
         """Deletes an attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_attribute_with_http_info(attribute_category, attribute_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_attribute_with_http_info(attribute_category, attribute_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :return: None
@@ -185,7 +185,7 @@ class AttributesApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -245,7 +245,7 @@ class AttributesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -255,17 +255,17 @@ class AttributesApi(object):
         """Lists all attributes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_attributes(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_attributes(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAttributes
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_attributes_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_attributes_with_http_info(**kwargs)  # noqa: E501
@@ -275,18 +275,18 @@ class AttributesApi(object):
         """Lists all attributes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_attributes_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_attributes_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAttributes
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -334,7 +334,7 @@ class AttributesApi(object):
             files=local_var_files,
             response_type='GetAttributes',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -344,11 +344,11 @@ class AttributesApi(object):
         """Updates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_attribute(attribute_category, attribute_name, update_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_attribute(attribute_category, attribute_name, update_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :param UpdateAttribute update_attribute: Values to update an attribute (required)
@@ -357,7 +357,7 @@ class AttributesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, **kwargs)  # noqa: E501
         else:
             (data) = self.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, **kwargs)  # noqa: E501
@@ -367,11 +367,11 @@ class AttributesApi(object):
         """Updates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :param UpdateAttribute update_attribute: Values to update an attribute (required)
@@ -381,7 +381,7 @@ class AttributesApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name', 'update_attribute']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -447,7 +447,7 @@ class AttributesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/contacts_api.py
+++ b/sib_api_v3_sdk/api/contacts_api.py
@@ -37,11 +37,11 @@ class ContactsApi(object):
         """Add existing contacts to a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_contact_to_list(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_contact_to_list(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param AddContactToList contact_emails: Emails addresses of the contacts (required)
         :return: PostContactInfo
@@ -49,7 +49,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.add_contact_to_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
         else:
             (data) = self.add_contact_to_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class ContactsApi(object):
         """Add existing contacts to a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_contact_to_list_with_http_info(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_contact_to_list_with_http_info(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param AddContactToList contact_emails: Emails addresses of the contacts (required)
         :return: PostContactInfo
@@ -72,7 +72,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id', 'contact_emails']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='PostContactInfo',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,11 +142,11 @@ class ContactsApi(object):
         """Creates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_attribute(attribute_category, attribute_name, create_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_attribute(attribute_category, attribute_name, create_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the attribute (required)
         :param CreateAttribute create_attribute: Values to create an attribute (required)
@@ -155,7 +155,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, **kwargs)  # noqa: E501
         else:
             (data) = self.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, **kwargs)  # noqa: E501
@@ -165,11 +165,11 @@ class ContactsApi(object):
         """Creates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_attribute_with_http_info(attribute_category, attribute_name, create_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the attribute (required)
         :param CreateAttribute create_attribute: Values to create an attribute (required)
@@ -179,7 +179,7 @@ class ContactsApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name', 'create_attribute']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -245,7 +245,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -255,18 +255,18 @@ class ContactsApi(object):
         """Create a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_contact(create_contact, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_contact(create_contact, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateContact create_contact: Values to create a contact (required)
         :return: CreateUpdateContactModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_contact_with_http_info(create_contact, **kwargs)  # noqa: E501
         else:
             (data) = self.create_contact_with_http_info(create_contact, **kwargs)  # noqa: E501
@@ -276,11 +276,11 @@ class ContactsApi(object):
         """Create a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_contact_with_http_info(create_contact, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_contact_with_http_info(create_contact, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateContact create_contact: Values to create a contact (required)
         :return: CreateUpdateContactModel
                  If the method is called asynchronously,
@@ -288,7 +288,7 @@ class ContactsApi(object):
         """
 
         all_params = ['create_contact']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -342,7 +342,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='CreateUpdateContactModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -352,18 +352,18 @@ class ContactsApi(object):
         """Create a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_folder(create_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_folder(create_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateUpdateFolder create_folder: Name of the folder (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_folder_with_http_info(create_folder, **kwargs)  # noqa: E501
         else:
             (data) = self.create_folder_with_http_info(create_folder, **kwargs)  # noqa: E501
@@ -373,11 +373,11 @@ class ContactsApi(object):
         """Create a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_folder_with_http_info(create_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_folder_with_http_info(create_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateUpdateFolder create_folder: Name of the folder (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -385,7 +385,7 @@ class ContactsApi(object):
         """
 
         all_params = ['create_folder']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -439,7 +439,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -449,18 +449,18 @@ class ContactsApi(object):
         """Create a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_list(create_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_list(create_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateList create_list: Values to create a list (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_list_with_http_info(create_list, **kwargs)  # noqa: E501
         else:
             (data) = self.create_list_with_http_info(create_list, **kwargs)  # noqa: E501
@@ -470,11 +470,11 @@ class ContactsApi(object):
         """Create a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_list_with_http_info(create_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_list_with_http_info(create_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateList create_list: Values to create a list (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -482,7 +482,7 @@ class ContactsApi(object):
         """
 
         all_params = ['create_list']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -536,7 +536,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -546,11 +546,11 @@ class ContactsApi(object):
         """Deletes an attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_attribute(attribute_category, attribute_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_attribute(attribute_category, attribute_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :return: None
@@ -558,7 +558,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_attribute_with_http_info(attribute_category, attribute_name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_attribute_with_http_info(attribute_category, attribute_name, **kwargs)  # noqa: E501
@@ -568,11 +568,11 @@ class ContactsApi(object):
         """Deletes an attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_attribute_with_http_info(attribute_category, attribute_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_attribute_with_http_info(attribute_category, attribute_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :return: None
@@ -581,7 +581,7 @@ class ContactsApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -641,7 +641,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -651,18 +651,18 @@ class ContactsApi(object):
         """Deletes a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_contact(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_contact(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_contact_with_http_info(email, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_contact_with_http_info(email, **kwargs)  # noqa: E501
@@ -672,11 +672,11 @@ class ContactsApi(object):
         """Deletes a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_contact_with_http_info(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_contact_with_http_info(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :return: None
                  If the method is called asynchronously,
@@ -684,7 +684,7 @@ class ContactsApi(object):
         """
 
         all_params = ['email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -738,7 +738,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -748,18 +748,18 @@ class ContactsApi(object):
         """Delete a folder (and all its lists)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_folder(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_folder(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -769,11 +769,11 @@ class ContactsApi(object):
         """Delete a folder (and all its lists)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_folder_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_folder_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :return: None
                  If the method is called asynchronously,
@@ -781,7 +781,7 @@ class ContactsApi(object):
         """
 
         all_params = ['folder_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -835,7 +835,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -845,18 +845,18 @@ class ContactsApi(object):
         """Delete a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -866,11 +866,11 @@ class ContactsApi(object):
         """Delete a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: None
                  If the method is called asynchronously,
@@ -878,7 +878,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -932,7 +932,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -942,17 +942,17 @@ class ContactsApi(object):
         """Lists all attributes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_attributes(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_attributes(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAttributes
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_attributes_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_attributes_with_http_info(**kwargs)  # noqa: E501
@@ -962,18 +962,18 @@ class ContactsApi(object):
         """Lists all attributes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_attributes_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_attributes_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetAttributes
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1021,7 +1021,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetAttributes',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1031,18 +1031,18 @@ class ContactsApi(object):
         """Retrieves contact informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contact_info(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contact_info(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :return: GetExtendedContactDetails
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_contact_info_with_http_info(email, **kwargs)  # noqa: E501
         else:
             (data) = self.get_contact_info_with_http_info(email, **kwargs)  # noqa: E501
@@ -1052,11 +1052,11 @@ class ContactsApi(object):
         """Retrieves contact informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contact_info_with_http_info(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contact_info_with_http_info(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :return: GetExtendedContactDetails
                  If the method is called asynchronously,
@@ -1064,7 +1064,7 @@ class ContactsApi(object):
         """
 
         all_params = ['email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1118,7 +1118,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetExtendedContactDetails',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1128,18 +1128,18 @@ class ContactsApi(object):
         """Get the campaigns statistics for a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contact_stats(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contact_stats(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email address (urlencoded) of the contact (required)
         :return: GetContactCampaignStats
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_contact_stats_with_http_info(email, **kwargs)  # noqa: E501
         else:
             (data) = self.get_contact_stats_with_http_info(email, **kwargs)  # noqa: E501
@@ -1149,11 +1149,11 @@ class ContactsApi(object):
         """Get the campaigns statistics for a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contact_stats_with_http_info(email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contact_stats_with_http_info(email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email address (urlencoded) of the contact (required)
         :return: GetContactCampaignStats
                  If the method is called asynchronously,
@@ -1161,7 +1161,7 @@ class ContactsApi(object):
         """
 
         all_params = ['email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1215,7 +1215,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetContactCampaignStats',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1225,11 +1225,11 @@ class ContactsApi(object):
         """Get all the contacts  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
@@ -1238,7 +1238,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_contacts_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_contacts_with_http_info(**kwargs)  # noqa: E501
@@ -1248,11 +1248,11 @@ class ContactsApi(object):
         """Get all the contacts  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
@@ -1262,7 +1262,7 @@ class ContactsApi(object):
         """
 
         all_params = ['limit', 'offset', 'modified_since']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1318,7 +1318,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetContacts',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1328,11 +1328,11 @@ class ContactsApi(object):
         """Get the contacts in a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts_from_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts_from_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
         :param int limit: Number of documents per page
@@ -1342,7 +1342,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_contacts_from_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_contacts_from_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -1352,11 +1352,11 @@ class ContactsApi(object):
         """Get the contacts in a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts_from_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts_from_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
         :param int limit: Number of documents per page
@@ -1367,7 +1367,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id', 'modified_since', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1429,7 +1429,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetContacts',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1439,18 +1439,18 @@ class ContactsApi(object):
         """Returns folder details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: id of the folder (required)
         :return: GetFolder
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -1460,11 +1460,11 @@ class ContactsApi(object):
         """Returns folder details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: id of the folder (required)
         :return: GetFolder
                  If the method is called asynchronously,
@@ -1472,7 +1472,7 @@ class ContactsApi(object):
         """
 
         all_params = ['folder_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1526,7 +1526,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetFolder',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1536,11 +1536,11 @@ class ContactsApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -1549,7 +1549,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -1559,11 +1559,11 @@ class ContactsApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -1573,7 +1573,7 @@ class ContactsApi(object):
         """
 
         all_params = ['folder_id', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1633,7 +1633,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetFolderLists',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1643,11 +1643,11 @@ class ContactsApi(object):
         """Get all the folders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folders(limit, offset, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folders(limit, offset, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page (required)
         :param int offset: Index of the first document of the page (required)
         :return: GetFolders
@@ -1655,7 +1655,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folders_with_http_info(limit, offset, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folders_with_http_info(limit, offset, **kwargs)  # noqa: E501
@@ -1665,11 +1665,11 @@ class ContactsApi(object):
         """Get all the folders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folders_with_http_info(limit, offset, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folders_with_http_info(limit, offset, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page (required)
         :param int offset: Index of the first document of the page (required)
         :return: GetFolders
@@ -1678,7 +1678,7 @@ class ContactsApi(object):
         """
 
         all_params = ['limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1740,7 +1740,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetFolders',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1750,18 +1750,18 @@ class ContactsApi(object):
         """Get the details of a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: GetExtendedList
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -1771,11 +1771,11 @@ class ContactsApi(object):
         """Get the details of a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: GetExtendedList
                  If the method is called asynchronously,
@@ -1783,7 +1783,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1837,7 +1837,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetExtendedList',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1847,11 +1847,11 @@ class ContactsApi(object):
         """Get all the lists  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_lists(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_lists(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :return: GetLists
@@ -1859,7 +1859,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_lists_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_lists_with_http_info(**kwargs)  # noqa: E501
@@ -1869,11 +1869,11 @@ class ContactsApi(object):
         """Get all the lists  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_lists_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_lists_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :return: GetLists
@@ -1882,7 +1882,7 @@ class ContactsApi(object):
         """
 
         all_params = ['limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1936,7 +1936,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='GetLists',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1947,18 +1947,18 @@ class ContactsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.import_contacts(request_contact_import, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.import_contacts(request_contact_import, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param RequestContactImport request_contact_import: Values to import contacts in Sendinblue. To know more about the expected format, please have a look at ``https://help.sendinblue.com/hc/en-us/articles/209499265-Build-contacts-lists-for-your-email-marketing-campaigns`` (required)
         :return: CreatedProcessId
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.import_contacts_with_http_info(request_contact_import, **kwargs)  # noqa: E501
         else:
             (data) = self.import_contacts_with_http_info(request_contact_import, **kwargs)  # noqa: E501
@@ -1969,11 +1969,11 @@ class ContactsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.import_contacts_with_http_info(request_contact_import, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.import_contacts_with_http_info(request_contact_import, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param RequestContactImport request_contact_import: Values to import contacts in Sendinblue. To know more about the expected format, please have a look at ``https://help.sendinblue.com/hc/en-us/articles/209499265-Build-contacts-lists-for-your-email-marketing-campaigns`` (required)
         :return: CreatedProcessId
                  If the method is called asynchronously,
@@ -1981,7 +1981,7 @@ class ContactsApi(object):
         """
 
         all_params = ['request_contact_import']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2035,7 +2035,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='CreatedProcessId',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2045,11 +2045,11 @@ class ContactsApi(object):
         """Remove existing contacts from a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_contact_from_list(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_contact_from_list(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param RemoveContactFromList contact_emails: Emails adresses of the contact (required)
         :return: PostContactInfo
@@ -2057,7 +2057,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.remove_contact_from_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
         else:
             (data) = self.remove_contact_from_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
@@ -2067,11 +2067,11 @@ class ContactsApi(object):
         """Remove existing contacts from a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_contact_from_list_with_http_info(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_contact_from_list_with_http_info(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param RemoveContactFromList contact_emails: Emails adresses of the contact (required)
         :return: PostContactInfo
@@ -2080,7 +2080,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id', 'contact_emails']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2140,7 +2140,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='PostContactInfo',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2151,18 +2151,18 @@ class ContactsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input. File will be available in csv.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.request_contact_export(request_contact_export, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.request_contact_export(request_contact_export, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param RequestContactExport request_contact_export: Values to request a contact export (required)
         :return: CreatedProcessId
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.request_contact_export_with_http_info(request_contact_export, **kwargs)  # noqa: E501
         else:
             (data) = self.request_contact_export_with_http_info(request_contact_export, **kwargs)  # noqa: E501
@@ -2173,11 +2173,11 @@ class ContactsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input. File will be available in csv.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.request_contact_export_with_http_info(request_contact_export, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.request_contact_export_with_http_info(request_contact_export, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param RequestContactExport request_contact_export: Values to request a contact export (required)
         :return: CreatedProcessId
                  If the method is called asynchronously,
@@ -2185,7 +2185,7 @@ class ContactsApi(object):
         """
 
         all_params = ['request_contact_export']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2239,7 +2239,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type='CreatedProcessId',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2249,11 +2249,11 @@ class ContactsApi(object):
         """Updates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_attribute(attribute_category, attribute_name, update_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_attribute(attribute_category, attribute_name, update_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :param UpdateAttribute update_attribute: Values to update an attribute (required)
@@ -2262,7 +2262,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, **kwargs)  # noqa: E501
         else:
             (data) = self.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, **kwargs)  # noqa: E501
@@ -2272,11 +2272,11 @@ class ContactsApi(object):
         """Updates contact attribute  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_attribute_with_http_info(attribute_category, attribute_name, update_attribute, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str attribute_category: Category of the attribute (required)
         :param str attribute_name: Name of the existing attribute (required)
         :param UpdateAttribute update_attribute: Values to update an attribute (required)
@@ -2286,7 +2286,7 @@ class ContactsApi(object):
         """
 
         all_params = ['attribute_category', 'attribute_name', 'update_attribute']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2352,7 +2352,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2362,11 +2362,11 @@ class ContactsApi(object):
         """Updates a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_contact(email, update_contact, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_contact(email, update_contact, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :param UpdateContact update_contact: Values to update a contact (required)
         :return: None
@@ -2374,7 +2374,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_contact_with_http_info(email, update_contact, **kwargs)  # noqa: E501
         else:
             (data) = self.update_contact_with_http_info(email, update_contact, **kwargs)  # noqa: E501
@@ -2384,11 +2384,11 @@ class ContactsApi(object):
         """Updates a contact  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_contact_with_http_info(email, update_contact, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_contact_with_http_info(email, update_contact, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str email: Email (urlencoded) of the contact (required)
         :param UpdateContact update_contact: Values to update a contact (required)
         :return: None
@@ -2397,7 +2397,7 @@ class ContactsApi(object):
         """
 
         all_params = ['email', 'update_contact']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2457,7 +2457,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2467,11 +2467,11 @@ class ContactsApi(object):
         """Update a contact folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_folder(folder_id, update_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_folder(folder_id, update_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param CreateUpdateFolder update_folder: Name of the folder (required)
         :return: None
@@ -2479,7 +2479,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_folder_with_http_info(folder_id, update_folder, **kwargs)  # noqa: E501
         else:
             (data) = self.update_folder_with_http_info(folder_id, update_folder, **kwargs)  # noqa: E501
@@ -2489,11 +2489,11 @@ class ContactsApi(object):
         """Update a contact folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_folder_with_http_info(folder_id, update_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_folder_with_http_info(folder_id, update_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param CreateUpdateFolder update_folder: Name of the folder (required)
         :return: None
@@ -2502,7 +2502,7 @@ class ContactsApi(object):
         """
 
         all_params = ['folder_id', 'update_folder']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2562,7 +2562,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -2572,11 +2572,11 @@ class ContactsApi(object):
         """Update a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_list(list_id, update_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_list(list_id, update_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param UpdateList update_list: Values to update a list (required)
         :return: None
@@ -2584,7 +2584,7 @@ class ContactsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_list_with_http_info(list_id, update_list, **kwargs)  # noqa: E501
         else:
             (data) = self.update_list_with_http_info(list_id, update_list, **kwargs)  # noqa: E501
@@ -2594,11 +2594,11 @@ class ContactsApi(object):
         """Update a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_list_with_http_info(list_id, update_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_list_with_http_info(list_id, update_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param UpdateList update_list: Values to update a list (required)
         :return: None
@@ -2607,7 +2607,7 @@ class ContactsApi(object):
         """
 
         all_params = ['list_id', 'update_list']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -2667,7 +2667,7 @@ class ContactsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/email_campaigns_api.py
+++ b/sib_api_v3_sdk/api/email_campaigns_api.py
@@ -37,18 +37,18 @@ class EmailCampaignsApi(object):
         """Create an email campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_email_campaign(email_campaigns, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_email_campaign(email_campaigns, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateEmailCampaign email_campaigns: Values to create a campaign (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_email_campaign_with_http_info(email_campaigns, **kwargs)  # noqa: E501
         else:
             (data) = self.create_email_campaign_with_http_info(email_campaigns, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class EmailCampaignsApi(object):
         """Create an email campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_email_campaign_with_http_info(email_campaigns, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_email_campaign_with_http_info(email_campaigns, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateEmailCampaign email_campaigns: Values to create a campaign (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['email_campaigns']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,18 +134,18 @@ class EmailCampaignsApi(object):
         """Delete an email campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_campaign(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_email_campaign(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_email_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_email_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class EmailCampaignsApi(object):
         """Delete an email campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_email_campaign_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_email_campaign_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
@@ -167,7 +167,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -231,11 +231,11 @@ class EmailCampaignsApi(object):
         """Export the recipients of a campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.email_export_recipients(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.email_export_recipients(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param EmailExportRecipients recipient_export: Values to send for a recipient export request
         :return: CreatedProcessId
@@ -243,7 +243,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.email_export_recipients_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.email_export_recipients_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -253,11 +253,11 @@ class EmailCampaignsApi(object):
         """Export the recipients of a campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.email_export_recipients_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.email_export_recipients_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param EmailExportRecipients recipient_export: Values to send for a recipient export request
         :return: CreatedProcessId
@@ -266,7 +266,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'recipient_export']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -322,7 +322,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type='CreatedProcessId',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -332,18 +332,18 @@ class EmailCampaignsApi(object):
         """Get campaign informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_campaign(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_campaign(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :return: GetEmailCampaign
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_email_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_email_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -353,11 +353,11 @@ class EmailCampaignsApi(object):
         """Get campaign informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_campaign_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_campaign_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :return: GetEmailCampaign
                  If the method is called asynchronously,
@@ -365,7 +365,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -419,7 +419,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type='GetEmailCampaign',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -429,11 +429,11 @@ class EmailCampaignsApi(object):
         """Return all your created campaigns  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_campaigns(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_campaigns(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str type: Filter on the type of the campaigns
         :param str status: Filter on the status of the campaign
         :param datetime start_date: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
@@ -445,7 +445,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_email_campaigns_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_email_campaigns_with_http_info(**kwargs)  # noqa: E501
@@ -455,11 +455,11 @@ class EmailCampaignsApi(object):
         """Return all your created campaigns  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_campaigns_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_campaigns_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str type: Filter on the type of the campaigns
         :param str status: Filter on the status of the campaign
         :param datetime start_date: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
@@ -472,7 +472,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['type', 'status', 'start_date', 'end_date', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -534,7 +534,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type='GetEmailCampaigns',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -544,18 +544,18 @@ class EmailCampaignsApi(object):
         """Send an email campaign id of the campaign immediately  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_email_campaign_now(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_email_campaign_now(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_email_campaign_now_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.send_email_campaign_now_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -565,11 +565,11 @@ class EmailCampaignsApi(object):
         """Send an email campaign id of the campaign immediately  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_email_campaign_now_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_email_campaign_now_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
@@ -577,7 +577,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -631,7 +631,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -642,11 +642,11 @@ class EmailCampaignsApi(object):
 
         A PDF will be sent to the specified email addresses  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_report(campaign_id, send_report, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_report(campaign_id, send_report, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param SendReport send_report: Values for send a report (required)
         :return: None
@@ -654,7 +654,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_report_with_http_info(campaign_id, send_report, **kwargs)  # noqa: E501
         else:
             (data) = self.send_report_with_http_info(campaign_id, send_report, **kwargs)  # noqa: E501
@@ -665,11 +665,11 @@ class EmailCampaignsApi(object):
 
         A PDF will be sent to the specified email addresses  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_report_with_http_info(campaign_id, send_report, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_report_with_http_info(campaign_id, send_report, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param SendReport send_report: Values for send a report (required)
         :return: None
@@ -678,7 +678,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'send_report']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -738,7 +738,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -748,11 +748,11 @@ class EmailCampaignsApi(object):
         """Send an email campaign to your test list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_email(campaign_id, email_to, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_email(campaign_id, email_to, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param SendTestEmail email_to: (required)
         :return: None
@@ -760,7 +760,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_test_email_with_http_info(campaign_id, email_to, **kwargs)  # noqa: E501
         else:
             (data) = self.send_test_email_with_http_info(campaign_id, email_to, **kwargs)  # noqa: E501
@@ -770,11 +770,11 @@ class EmailCampaignsApi(object):
         """Send an email campaign to your test list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_email_with_http_info(campaign_id, email_to, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_email_with_http_info(campaign_id, email_to, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param SendTestEmail email_to: (required)
         :return: None
@@ -783,7 +783,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'email_to']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -843,7 +843,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -853,11 +853,11 @@ class EmailCampaignsApi(object):
         """Update a campaign status  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_campaign_status(campaign_id, status, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_campaign_status(campaign_id, status, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param UpdateCampaignStatus status: Status of the campaign (required)
         :return: None
@@ -865,7 +865,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_campaign_status_with_http_info(campaign_id, status, **kwargs)  # noqa: E501
         else:
             (data) = self.update_campaign_status_with_http_info(campaign_id, status, **kwargs)  # noqa: E501
@@ -875,11 +875,11 @@ class EmailCampaignsApi(object):
         """Update a campaign status  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_campaign_status_with_http_info(campaign_id, status, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_campaign_status_with_http_info(campaign_id, status, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param UpdateCampaignStatus status: Status of the campaign (required)
         :return: None
@@ -888,7 +888,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'status']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -948,7 +948,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -958,11 +958,11 @@ class EmailCampaignsApi(object):
         """Update a campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_campaign(campaign_id, email_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_email_campaign(campaign_id, email_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param UpdateEmailCampaign email_campaign: Values to update a campaign (required)
         :return: None
@@ -970,7 +970,7 @@ class EmailCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_email_campaign_with_http_info(campaign_id, email_campaign, **kwargs)  # noqa: E501
         else:
             (data) = self.update_email_campaign_with_http_info(campaign_id, email_campaign, **kwargs)  # noqa: E501
@@ -980,11 +980,11 @@ class EmailCampaignsApi(object):
         """Update a campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_email_campaign_with_http_info(campaign_id, email_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_email_campaign_with_http_info(campaign_id, email_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the campaign (required)
         :param UpdateEmailCampaign email_campaign: Values to update a campaign (required)
         :return: None
@@ -993,7 +993,7 @@ class EmailCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'email_campaign']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1053,7 +1053,7 @@ class EmailCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/folders_api.py
+++ b/sib_api_v3_sdk/api/folders_api.py
@@ -37,18 +37,18 @@ class FoldersApi(object):
         """Create a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_folder(create_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_folder(create_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateUpdateFolder create_folder: Name of the folder (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_folder_with_http_info(create_folder, **kwargs)  # noqa: E501
         else:
             (data) = self.create_folder_with_http_info(create_folder, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class FoldersApi(object):
         """Create a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_folder_with_http_info(create_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_folder_with_http_info(create_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateUpdateFolder create_folder: Name of the folder (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class FoldersApi(object):
         """
 
         all_params = ['create_folder']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,18 +134,18 @@ class FoldersApi(object):
         """Delete a folder (and all its lists)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_folder(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_folder(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class FoldersApi(object):
         """Delete a folder (and all its lists)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_folder_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_folder_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :return: None
                  If the method is called asynchronously,
@@ -167,7 +167,7 @@ class FoldersApi(object):
         """
 
         all_params = ['folder_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -231,18 +231,18 @@ class FoldersApi(object):
         """Returns folder details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: id of the folder (required)
         :return: GetFolder
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folder_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -252,11 +252,11 @@ class FoldersApi(object):
         """Returns folder details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: id of the folder (required)
         :return: GetFolder
                  If the method is called asynchronously,
@@ -264,7 +264,7 @@ class FoldersApi(object):
         """
 
         all_params = ['folder_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -318,7 +318,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type='GetFolder',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -328,11 +328,11 @@ class FoldersApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -341,7 +341,7 @@ class FoldersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -351,11 +351,11 @@ class FoldersApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -365,7 +365,7 @@ class FoldersApi(object):
         """
 
         all_params = ['folder_id', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -425,7 +425,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type='GetFolderLists',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -435,11 +435,11 @@ class FoldersApi(object):
         """Get all the folders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folders(limit, offset, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folders(limit, offset, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page (required)
         :param int offset: Index of the first document of the page (required)
         :return: GetFolders
@@ -447,7 +447,7 @@ class FoldersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folders_with_http_info(limit, offset, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folders_with_http_info(limit, offset, **kwargs)  # noqa: E501
@@ -457,11 +457,11 @@ class FoldersApi(object):
         """Get all the folders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folders_with_http_info(limit, offset, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folders_with_http_info(limit, offset, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page (required)
         :param int offset: Index of the first document of the page (required)
         :return: GetFolders
@@ -470,7 +470,7 @@ class FoldersApi(object):
         """
 
         all_params = ['limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -532,7 +532,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type='GetFolders',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -542,11 +542,11 @@ class FoldersApi(object):
         """Update a contact folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_folder(folder_id, update_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_folder(folder_id, update_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param CreateUpdateFolder update_folder: Name of the folder (required)
         :return: None
@@ -554,7 +554,7 @@ class FoldersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_folder_with_http_info(folder_id, update_folder, **kwargs)  # noqa: E501
         else:
             (data) = self.update_folder_with_http_info(folder_id, update_folder, **kwargs)  # noqa: E501
@@ -564,11 +564,11 @@ class FoldersApi(object):
         """Update a contact folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_folder_with_http_info(folder_id, update_folder, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_folder_with_http_info(folder_id, update_folder, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param CreateUpdateFolder update_folder: Name of the folder (required)
         :return: None
@@ -577,7 +577,7 @@ class FoldersApi(object):
         """
 
         all_params = ['folder_id', 'update_folder']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -637,7 +637,7 @@ class FoldersApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/lists_api.py
+++ b/sib_api_v3_sdk/api/lists_api.py
@@ -37,11 +37,11 @@ class ListsApi(object):
         """Add existing contacts to a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_contact_to_list(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_contact_to_list(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param AddContactToList contact_emails: Emails addresses of the contacts (required)
         :return: PostContactInfo
@@ -49,7 +49,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.add_contact_to_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
         else:
             (data) = self.add_contact_to_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class ListsApi(object):
         """Add existing contacts to a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_contact_to_list_with_http_info(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_contact_to_list_with_http_info(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param AddContactToList contact_emails: Emails addresses of the contacts (required)
         :return: PostContactInfo
@@ -72,7 +72,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id', 'contact_emails']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='PostContactInfo',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,18 +142,18 @@ class ListsApi(object):
         """Create a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_list(create_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_list(create_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateList create_list: Values to create a list (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_list_with_http_info(create_list, **kwargs)  # noqa: E501
         else:
             (data) = self.create_list_with_http_info(create_list, **kwargs)  # noqa: E501
@@ -163,11 +163,11 @@ class ListsApi(object):
         """Create a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_list_with_http_info(create_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_list_with_http_info(create_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateList create_list: Values to create a list (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -175,7 +175,7 @@ class ListsApi(object):
         """
 
         all_params = ['create_list']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -229,7 +229,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -239,18 +239,18 @@ class ListsApi(object):
         """Delete a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -260,11 +260,11 @@ class ListsApi(object):
         """Delete a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: None
                  If the method is called asynchronously,
@@ -272,7 +272,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class ListsApi(object):
         """Get the contacts in a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts_from_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts_from_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
         :param int limit: Number of documents per page
@@ -350,7 +350,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_contacts_from_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_contacts_from_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -360,11 +360,11 @@ class ListsApi(object):
         """Get the contacts in a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_contacts_from_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_contacts_from_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param datetime modified_since: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
         :param int limit: Number of documents per page
@@ -375,7 +375,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id', 'modified_since', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -437,7 +437,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='GetContacts',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -447,11 +447,11 @@ class ListsApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -460,7 +460,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_folder_lists_with_http_info(folder_id, **kwargs)  # noqa: E501
@@ -470,11 +470,11 @@ class ListsApi(object):
         """Get the lists in a folder  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_folder_lists_with_http_info(folder_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_folder_lists_with_http_info(folder_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int folder_id: Id of the folder (required)
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
@@ -484,7 +484,7 @@ class ListsApi(object):
         """
 
         all_params = ['folder_id', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -544,7 +544,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='GetFolderLists',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -554,18 +554,18 @@ class ListsApi(object):
         """Get the details of a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_list(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_list(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: GetExtendedList
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_list_with_http_info(list_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_list_with_http_info(list_id, **kwargs)  # noqa: E501
@@ -575,11 +575,11 @@ class ListsApi(object):
         """Get the details of a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_list_with_http_info(list_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_list_with_http_info(list_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :return: GetExtendedList
                  If the method is called asynchronously,
@@ -587,7 +587,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -641,7 +641,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='GetExtendedList',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -651,11 +651,11 @@ class ListsApi(object):
         """Get all the lists  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_lists(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_lists(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :return: GetLists
@@ -663,7 +663,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_lists_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_lists_with_http_info(**kwargs)  # noqa: E501
@@ -673,11 +673,11 @@ class ListsApi(object):
         """Get all the lists  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_lists_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_lists_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param int offset: Index of the first document of the page
         :return: GetLists
@@ -686,7 +686,7 @@ class ListsApi(object):
         """
 
         all_params = ['limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -740,7 +740,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='GetLists',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -750,11 +750,11 @@ class ListsApi(object):
         """Remove existing contacts from a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_contact_from_list(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_contact_from_list(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param RemoveContactFromList contact_emails: Emails adresses of the contact (required)
         :return: PostContactInfo
@@ -762,7 +762,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.remove_contact_from_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
         else:
             (data) = self.remove_contact_from_list_with_http_info(list_id, contact_emails, **kwargs)  # noqa: E501
@@ -772,11 +772,11 @@ class ListsApi(object):
         """Remove existing contacts from a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_contact_from_list_with_http_info(list_id, contact_emails, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_contact_from_list_with_http_info(list_id, contact_emails, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param RemoveContactFromList contact_emails: Emails adresses of the contact (required)
         :return: PostContactInfo
@@ -785,7 +785,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id', 'contact_emails']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -845,7 +845,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type='PostContactInfo',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -855,11 +855,11 @@ class ListsApi(object):
         """Update a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_list(list_id, update_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_list(list_id, update_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param UpdateList update_list: Values to update a list (required)
         :return: None
@@ -867,7 +867,7 @@ class ListsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_list_with_http_info(list_id, update_list, **kwargs)  # noqa: E501
         else:
             (data) = self.update_list_with_http_info(list_id, update_list, **kwargs)  # noqa: E501
@@ -877,11 +877,11 @@ class ListsApi(object):
         """Update a list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_list_with_http_info(list_id, update_list, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_list_with_http_info(list_id, update_list, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int list_id: Id of the list (required)
         :param UpdateList update_list: Values to update a list (required)
         :return: None
@@ -890,7 +890,7 @@ class ListsApi(object):
         """
 
         all_params = ['list_id', 'update_list']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -950,7 +950,7 @@ class ListsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/process_api.py
+++ b/sib_api_v3_sdk/api/process_api.py
@@ -37,18 +37,18 @@ class ProcessApi(object):
         """Return the informations for a process  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_process(process_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_process(process_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int process_id: Id of the process (required)
         :return: GetProcess
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_process_with_http_info(process_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_process_with_http_info(process_id, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class ProcessApi(object):
         """Return the informations for a process  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_process_with_http_info(process_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_process_with_http_info(process_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int process_id: Id of the process (required)
         :return: GetProcess
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class ProcessApi(object):
         """
 
         all_params = ['process_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class ProcessApi(object):
             files=local_var_files,
             response_type='GetProcess',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,11 +134,11 @@ class ProcessApi(object):
         """Return all the processes for your account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_processes(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_processes(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number limitation for the result returned
         :param int offset: Beginning point in the list to retrieve from.
         :return: GetProcesses
@@ -146,7 +146,7 @@ class ProcessApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_processes_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_processes_with_http_info(**kwargs)  # noqa: E501
@@ -156,11 +156,11 @@ class ProcessApi(object):
         """Return all the processes for your account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_processes_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_processes_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number limitation for the result returned
         :param int offset: Beginning point in the list to retrieve from.
         :return: GetProcesses
@@ -169,7 +169,7 @@ class ProcessApi(object):
         """
 
         all_params = ['limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -223,7 +223,7 @@ class ProcessApi(object):
             files=local_var_files,
             response_type='GetProcesses',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/reseller_api.py
+++ b/sib_api_v3_sdk/api/reseller_api.py
@@ -37,11 +37,11 @@ class ResellerApi(object):
         """Add Email and/or SMS credits to a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_credits(child_auth_key, add_credits, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_credits(child_auth_key, add_credits, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param AddCredits add_credits: Values to post to add credit to a specific child account (required)
         :return: RemainingCreditModel
@@ -49,7 +49,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.add_credits_with_http_info(child_auth_key, add_credits, **kwargs)  # noqa: E501
         else:
             (data) = self.add_credits_with_http_info(child_auth_key, add_credits, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class ResellerApi(object):
         """Add Email and/or SMS credits to a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_credits_with_http_info(child_auth_key, add_credits, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.add_credits_with_http_info(child_auth_key, add_credits, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param AddCredits add_credits: Values to post to add credit to a specific child account (required)
         :return: RemainingCreditModel
@@ -72,7 +72,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'add_credits']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='RemainingCreditModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,11 +142,11 @@ class ResellerApi(object):
         """Associate a dedicated IP to the child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.associate_ip_to_child(child_auth_key, ip, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.associate_ip_to_child(child_auth_key, ip, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param ManageIp ip: IP to associate (required)
         :return: None
@@ -154,7 +154,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.associate_ip_to_child_with_http_info(child_auth_key, ip, **kwargs)  # noqa: E501
         else:
             (data) = self.associate_ip_to_child_with_http_info(child_auth_key, ip, **kwargs)  # noqa: E501
@@ -164,11 +164,11 @@ class ResellerApi(object):
         """Associate a dedicated IP to the child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.associate_ip_to_child_with_http_info(child_auth_key, ip, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.associate_ip_to_child_with_http_info(child_auth_key, ip, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param ManageIp ip: IP to associate (required)
         :return: None
@@ -177,7 +177,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'ip']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -237,7 +237,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -247,11 +247,11 @@ class ResellerApi(object):
         """Creates a domain for a child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_child_domain(child_auth_key, add_child_domain, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_child_domain(child_auth_key, add_child_domain, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param AddChildDomain add_child_domain: Sender domain to add for a specific child account (required)
         :return: None
@@ -259,7 +259,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_child_domain_with_http_info(child_auth_key, add_child_domain, **kwargs)  # noqa: E501
         else:
             (data) = self.create_child_domain_with_http_info(child_auth_key, add_child_domain, **kwargs)  # noqa: E501
@@ -269,11 +269,11 @@ class ResellerApi(object):
         """Creates a domain for a child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_child_domain_with_http_info(child_auth_key, add_child_domain, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_child_domain_with_http_info(child_auth_key, add_child_domain, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param AddChildDomain add_child_domain: Sender domain to add for a specific child account (required)
         :return: None
@@ -282,7 +282,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'add_child_domain']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -342,7 +342,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -352,18 +352,18 @@ class ResellerApi(object):
         """Creates a reseller child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_reseller_child(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_reseller_child(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateChild reseller_child: reseller child to add
         :return: CreateReseller
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_reseller_child_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.create_reseller_child_with_http_info(**kwargs)  # noqa: E501
@@ -373,11 +373,11 @@ class ResellerApi(object):
         """Creates a reseller child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_reseller_child_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_reseller_child_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateChild reseller_child: reseller child to add
         :return: CreateReseller
                  If the method is called asynchronously,
@@ -385,7 +385,7 @@ class ResellerApi(object):
         """
 
         all_params = ['reseller_child']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -435,7 +435,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='CreateReseller',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -445,11 +445,11 @@ class ResellerApi(object):
         """Deletes the sender domain of the reseller child based on the childAuthKey and domainName passed  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_child_domain(child_auth_key, domain_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_child_domain(child_auth_key, domain_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param str domain_name: Pass the existing domain that needs to be deleted (required)
         :return: None
@@ -457,7 +457,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_child_domain_with_http_info(child_auth_key, domain_name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_child_domain_with_http_info(child_auth_key, domain_name, **kwargs)  # noqa: E501
@@ -467,11 +467,11 @@ class ResellerApi(object):
         """Deletes the sender domain of the reseller child based on the childAuthKey and domainName passed  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_child_domain_with_http_info(child_auth_key, domain_name, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_child_domain_with_http_info(child_auth_key, domain_name, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param str domain_name: Pass the existing domain that needs to be deleted (required)
         :return: None
@@ -480,7 +480,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'domain_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -540,7 +540,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -550,18 +550,18 @@ class ResellerApi(object):
         """Deletes a single reseller child based on the childAuthKey supplied  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_reseller_child(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_reseller_child(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_reseller_child_with_http_info(child_auth_key, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_reseller_child_with_http_info(child_auth_key, **kwargs)  # noqa: E501
@@ -571,11 +571,11 @@ class ResellerApi(object):
         """Deletes a single reseller child based on the childAuthKey supplied  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_reseller_child_with_http_info(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_reseller_child_with_http_info(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: None
                  If the method is called asynchronously,
@@ -583,7 +583,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -637,7 +637,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -647,11 +647,11 @@ class ResellerApi(object):
         """Dissociate a dedicated IP to the child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.dissociate_ip_from_child(child_auth_key, ip, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.dissociate_ip_from_child(child_auth_key, ip, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param ManageIp ip: IP to dissociate (required)
         :return: None
@@ -659,7 +659,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.dissociate_ip_from_child_with_http_info(child_auth_key, ip, **kwargs)  # noqa: E501
         else:
             (data) = self.dissociate_ip_from_child_with_http_info(child_auth_key, ip, **kwargs)  # noqa: E501
@@ -669,11 +669,11 @@ class ResellerApi(object):
         """Dissociate a dedicated IP to the child  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.dissociate_ip_from_child_with_http_info(child_auth_key, ip, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.dissociate_ip_from_child_with_http_info(child_auth_key, ip, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param ManageIp ip: IP to dissociate (required)
         :return: None
@@ -682,7 +682,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'ip']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -742,7 +742,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -752,18 +752,18 @@ class ResellerApi(object):
         """Gets all the sender domains of a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_child_domains(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_child_domains(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetChildDomains
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_child_domains_with_http_info(child_auth_key, **kwargs)  # noqa: E501
         else:
             (data) = self.get_child_domains_with_http_info(child_auth_key, **kwargs)  # noqa: E501
@@ -773,11 +773,11 @@ class ResellerApi(object):
         """Gets all the sender domains of a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_child_domains_with_http_info(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_child_domains_with_http_info(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetChildDomains
                  If the method is called asynchronously,
@@ -785,7 +785,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -839,7 +839,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='GetChildDomains',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -849,18 +849,18 @@ class ResellerApi(object):
         """Gets the info about a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_child_info(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_child_info(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetChildInfo
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_child_info_with_http_info(child_auth_key, **kwargs)  # noqa: E501
         else:
             (data) = self.get_child_info_with_http_info(child_auth_key, **kwargs)  # noqa: E501
@@ -870,11 +870,11 @@ class ResellerApi(object):
         """Gets the info about a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_child_info_with_http_info(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_child_info_with_http_info(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetChildInfo
                  If the method is called asynchronously,
@@ -882,7 +882,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -936,7 +936,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='GetChildInfo',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -946,17 +946,17 @@ class ResellerApi(object):
         """Gets the list of all reseller&#39;s children accounts  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_reseller_childs(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_reseller_childs(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetChildrenList
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_reseller_childs_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_reseller_childs_with_http_info(**kwargs)  # noqa: E501
@@ -966,18 +966,18 @@ class ResellerApi(object):
         """Gets the list of all reseller&#39;s children accounts  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_reseller_childs_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_reseller_childs_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetChildrenList
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1025,7 +1025,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='GetChildrenList',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1035,18 +1035,18 @@ class ResellerApi(object):
         """Generates a session token which will remain valid for a short period of time only.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sso_token(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sso_token(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetSsoToken
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_sso_token_with_http_info(child_auth_key, **kwargs)  # noqa: E501
         else:
             (data) = self.get_sso_token_with_http_info(child_auth_key, **kwargs)  # noqa: E501
@@ -1056,11 +1056,11 @@ class ResellerApi(object):
         """Generates a session token which will remain valid for a short period of time only.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sso_token_with_http_info(child_auth_key, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sso_token_with_http_info(child_auth_key, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :return: GetSsoToken
                  If the method is called asynchronously,
@@ -1068,7 +1068,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1122,7 +1122,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='GetSsoToken',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1132,11 +1132,11 @@ class ResellerApi(object):
         """Remove Email and/or SMS credits from a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_credits(child_auth_key, remove_credits, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_credits(child_auth_key, remove_credits, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param RemoveCredits remove_credits: Values to post to remove email or SMS credits from a specific child account (required)
         :return: RemainingCreditModel
@@ -1144,7 +1144,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.remove_credits_with_http_info(child_auth_key, remove_credits, **kwargs)  # noqa: E501
         else:
             (data) = self.remove_credits_with_http_info(child_auth_key, remove_credits, **kwargs)  # noqa: E501
@@ -1154,11 +1154,11 @@ class ResellerApi(object):
         """Remove Email and/or SMS credits from a specific child account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_credits_with_http_info(child_auth_key, remove_credits, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.remove_credits_with_http_info(child_auth_key, remove_credits, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param RemoveCredits remove_credits: Values to post to remove email or SMS credits from a specific child account (required)
         :return: RemainingCreditModel
@@ -1167,7 +1167,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'remove_credits']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1227,7 +1227,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type='RemainingCreditModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1237,11 +1237,11 @@ class ResellerApi(object):
         """Updates the sender domain of reseller&#39;s child based on the childAuthKey and domainName passed  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_child_domain(child_auth_key, domain_name, update_child_domain, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_child_domain(child_auth_key, domain_name, update_child_domain, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param str domain_name: Pass the existing domain that needs to be updated (required)
         :param UpdateChildDomain update_child_domain: value to update for sender domain (required)
@@ -1250,7 +1250,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_child_domain_with_http_info(child_auth_key, domain_name, update_child_domain, **kwargs)  # noqa: E501
         else:
             (data) = self.update_child_domain_with_http_info(child_auth_key, domain_name, update_child_domain, **kwargs)  # noqa: E501
@@ -1260,11 +1260,11 @@ class ResellerApi(object):
         """Updates the sender domain of reseller&#39;s child based on the childAuthKey and domainName passed  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_child_domain_with_http_info(child_auth_key, domain_name, update_child_domain, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_child_domain_with_http_info(child_auth_key, domain_name, update_child_domain, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param str domain_name: Pass the existing domain that needs to be updated (required)
         :param UpdateChildDomain update_child_domain: value to update for sender domain (required)
@@ -1274,7 +1274,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'domain_name', 'update_child_domain']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1340,7 +1340,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1350,11 +1350,11 @@ class ResellerApi(object):
         """Updates infos of reseller&#39;s child based on the childAuthKey supplied  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_reseller_child(child_auth_key, reseller_child, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_reseller_child(child_auth_key, reseller_child, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param UpdateChild reseller_child: values to update in child profile (required)
         :return: None
@@ -1362,7 +1362,7 @@ class ResellerApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_reseller_child_with_http_info(child_auth_key, reseller_child, **kwargs)  # noqa: E501
         else:
             (data) = self.update_reseller_child_with_http_info(child_auth_key, reseller_child, **kwargs)  # noqa: E501
@@ -1372,11 +1372,11 @@ class ResellerApi(object):
         """Updates infos of reseller&#39;s child based on the childAuthKey supplied  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_reseller_child_with_http_info(child_auth_key, reseller_child, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_reseller_child_with_http_info(child_auth_key, reseller_child, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str child_auth_key: auth key of reseller's child (required)
         :param UpdateChild reseller_child: values to update in child profile (required)
         :return: None
@@ -1385,7 +1385,7 @@ class ResellerApi(object):
         """
 
         all_params = ['child_auth_key', 'reseller_child']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1445,7 +1445,7 @@ class ResellerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/senders_api.py
+++ b/sib_api_v3_sdk/api/senders_api.py
@@ -37,18 +37,18 @@ class SendersApi(object):
         """Create a new sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_sender(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_sender(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSender sender: sender's name
         :return: CreateSenderModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_sender_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.create_sender_with_http_info(**kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class SendersApi(object):
         """Create a new sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_sender_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_sender_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSender sender: sender's name
         :return: CreateSenderModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class SendersApi(object):
         """
 
         all_params = ['sender']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type='CreateSenderModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -130,18 +130,18 @@ class SendersApi(object):
         """Delete a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_sender(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_sender(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
@@ -151,11 +151,11 @@ class SendersApi(object):
         """Delete a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_sender_with_http_info(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_sender_with_http_info(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :return: None
                  If the method is called asynchronously,
@@ -163,7 +163,7 @@ class SendersApi(object):
         """
 
         all_params = ['sender_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -217,7 +217,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -227,17 +227,17 @@ class SendersApi(object):
         """Return all the dedicated IPs for your account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ips(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_ips(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetIps
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_ips_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_ips_with_http_info(**kwargs)  # noqa: E501
@@ -247,18 +247,18 @@ class SendersApi(object):
         """Return all the dedicated IPs for your account  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ips_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_ips_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :return: GetIps
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -306,7 +306,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type='GetIps',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -316,18 +316,18 @@ class SendersApi(object):
         """Return all the dedicated IPs for a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ips_from_sender(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_ips_from_sender(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :return: GetIpsFromSender
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_ips_from_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_ips_from_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
@@ -337,11 +337,11 @@ class SendersApi(object):
         """Return all the dedicated IPs for a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ips_from_sender_with_http_info(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_ips_from_sender_with_http_info(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :return: GetIpsFromSender
                  If the method is called asynchronously,
@@ -349,7 +349,7 @@ class SendersApi(object):
         """
 
         all_params = ['sender_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -403,7 +403,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type='GetIpsFromSender',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -413,11 +413,11 @@ class SendersApi(object):
         """Get the list of all your senders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_senders(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_senders(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str ip: Filter your senders for a specific ip (available for dedicated IP usage only)
         :param str domain: Filter your senders for a specific domain
         :return: GetSendersList
@@ -425,7 +425,7 @@ class SendersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_senders_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_senders_with_http_info(**kwargs)  # noqa: E501
@@ -435,11 +435,11 @@ class SendersApi(object):
         """Get the list of all your senders  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_senders_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_senders_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str ip: Filter your senders for a specific ip (available for dedicated IP usage only)
         :param str domain: Filter your senders for a specific domain
         :return: GetSendersList
@@ -448,7 +448,7 @@ class SendersApi(object):
         """
 
         all_params = ['ip', 'domain']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -500,7 +500,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type='GetSendersList',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -510,11 +510,11 @@ class SendersApi(object):
         """Update a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sender(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sender(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :param UpdateSender sender: sender's name
         :return: None
@@ -522,7 +522,7 @@ class SendersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
         else:
             (data) = self.update_sender_with_http_info(sender_id, **kwargs)  # noqa: E501
@@ -532,11 +532,11 @@ class SendersApi(object):
         """Update a sender  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sender_with_http_info(sender_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sender_with_http_info(sender_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int sender_id: Id of the sender (required)
         :param UpdateSender sender: sender's name
         :return: None
@@ -545,7 +545,7 @@ class SendersApi(object):
         """
 
         all_params = ['sender_id', 'sender']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -601,7 +601,7 @@ class SendersApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/sms_campaigns_api.py
+++ b/sib_api_v3_sdk/api/sms_campaigns_api.py
@@ -37,18 +37,18 @@ class SMSCampaignsApi(object):
         """Creates an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_sms_campaign(create_sms_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_sms_campaign(create_sms_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSmsCampaign create_sms_campaign: Values to create an SMS Campaign (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_sms_campaign_with_http_info(create_sms_campaign, **kwargs)  # noqa: E501
         else:
             (data) = self.create_sms_campaign_with_http_info(create_sms_campaign, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class SMSCampaignsApi(object):
         """Creates an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_sms_campaign_with_http_info(create_sms_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_sms_campaign_with_http_info(create_sms_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSmsCampaign create_sms_campaign: Values to create an SMS Campaign (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['create_sms_campaign']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,18 +134,18 @@ class SMSCampaignsApi(object):
         """Delete the SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_sms_campaign(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_sms_campaign(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_sms_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_sms_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class SMSCampaignsApi(object):
         """Delete the SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_sms_campaign_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_sms_campaign_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :return: None
                  If the method is called asynchronously,
@@ -167,7 +167,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -231,18 +231,18 @@ class SMSCampaignsApi(object):
         """Get an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_campaign(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_campaign(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :return: GetSmsCampaign
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_sms_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_sms_campaign_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -252,11 +252,11 @@ class SMSCampaignsApi(object):
         """Get an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_campaign_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_campaign_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :return: GetSmsCampaign
                  If the method is called asynchronously,
@@ -264,7 +264,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -318,7 +318,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type='GetSmsCampaign',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -328,11 +328,11 @@ class SMSCampaignsApi(object):
         """Returns the informations for all your created SMS campaigns  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_campaigns(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_campaigns(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str status: Status of campaign.
         :param datetime start_date: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
         :param datetime end_date: Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
@@ -343,7 +343,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_sms_campaigns_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_sms_campaigns_with_http_info(**kwargs)  # noqa: E501
@@ -353,11 +353,11 @@ class SMSCampaignsApi(object):
         """Returns the informations for all your created SMS campaigns  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_campaigns_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_campaigns_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str status: Status of campaign.
         :param datetime start_date: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
         :param datetime end_date: Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
@@ -369,7 +369,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['status', 'start_date', 'end_date', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -429,7 +429,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type='GetSmsCampaigns',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -440,11 +440,11 @@ class SMSCampaignsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.request_sms_recipient_export(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.request_sms_recipient_export(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param RequestSmsRecipientExport recipient_export: Values to send for a recipient export request
         :return: CreatedProcessId
@@ -452,7 +452,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.request_sms_recipient_export_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.request_sms_recipient_export_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -463,11 +463,11 @@ class SMSCampaignsApi(object):
 
         It returns the background process ID which on completion calls the notify URL that you have set in the input.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.request_sms_recipient_export_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.request_sms_recipient_export_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param RequestSmsRecipientExport recipient_export: Values to send for a recipient export request
         :return: CreatedProcessId
@@ -476,7 +476,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'recipient_export']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -532,7 +532,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type='CreatedProcessId',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -542,18 +542,18 @@ class SMSCampaignsApi(object):
         """Send your SMS campaign immediately  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_sms_campaign_now(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_sms_campaign_now(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_sms_campaign_now_with_http_info(campaign_id, **kwargs)  # noqa: E501
         else:
             (data) = self.send_sms_campaign_now_with_http_info(campaign_id, **kwargs)  # noqa: E501
@@ -563,11 +563,11 @@ class SMSCampaignsApi(object):
         """Send your SMS campaign immediately  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_sms_campaign_now_with_http_info(campaign_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_sms_campaign_now_with_http_info(campaign_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :return: None
                  If the method is called asynchronously,
@@ -575,7 +575,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -629,7 +629,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -640,11 +640,11 @@ class SMSCampaignsApi(object):
 
         Send report of Sent and Archived campaign, to the specified email addresses, with respective data and a pdf attachment in detail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_sms_report(campaign_id, send_report, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_sms_report(campaign_id, send_report, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param SendReport send_report: Values for send a report (required)
         :return: None
@@ -652,7 +652,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_sms_report_with_http_info(campaign_id, send_report, **kwargs)  # noqa: E501
         else:
             (data) = self.send_sms_report_with_http_info(campaign_id, send_report, **kwargs)  # noqa: E501
@@ -663,11 +663,11 @@ class SMSCampaignsApi(object):
 
         Send report of Sent and Archived campaign, to the specified email addresses, with respective data and a pdf attachment in detail.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_sms_report_with_http_info(campaign_id, send_report, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_sms_report_with_http_info(campaign_id, send_report, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param SendReport send_report: Values for send a report (required)
         :return: None
@@ -676,7 +676,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'send_report']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -736,7 +736,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -746,11 +746,11 @@ class SMSCampaignsApi(object):
         """Send an SMS  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_sms(campaign_id, phone_number, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_sms(campaign_id, phone_number, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the SMS campaign (required)
         :param SendTestSms phone_number: Mobile number of the recipient with the country code. This number must belong to one of your contacts in SendinBlue account and must not be blacklisted (required)
         :return: None
@@ -758,7 +758,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_test_sms_with_http_info(campaign_id, phone_number, **kwargs)  # noqa: E501
         else:
             (data) = self.send_test_sms_with_http_info(campaign_id, phone_number, **kwargs)  # noqa: E501
@@ -768,11 +768,11 @@ class SMSCampaignsApi(object):
         """Send an SMS  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_sms_with_http_info(campaign_id, phone_number, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_sms_with_http_info(campaign_id, phone_number, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: Id of the SMS campaign (required)
         :param SendTestSms phone_number: Mobile number of the recipient with the country code. This number must belong to one of your contacts in SendinBlue account and must not be blacklisted (required)
         :return: None
@@ -781,7 +781,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'phone_number']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -841,7 +841,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -851,11 +851,11 @@ class SMSCampaignsApi(object):
         """Updates an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sms_campaign(campaign_id, update_sms_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sms_campaign(campaign_id, update_sms_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :param UpdateSmsCampaign update_sms_campaign: Values to update an SMS Campaign (required)
         :return: None
@@ -863,7 +863,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_sms_campaign_with_http_info(campaign_id, update_sms_campaign, **kwargs)  # noqa: E501
         else:
             (data) = self.update_sms_campaign_with_http_info(campaign_id, update_sms_campaign, **kwargs)  # noqa: E501
@@ -873,11 +873,11 @@ class SMSCampaignsApi(object):
         """Updates an SMS campaign  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sms_campaign_with_http_info(campaign_id, update_sms_campaign, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sms_campaign_with_http_info(campaign_id, update_sms_campaign, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the SMS campaign (required)
         :param UpdateSmsCampaign update_sms_campaign: Values to update an SMS Campaign (required)
         :return: None
@@ -886,7 +886,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'update_sms_campaign']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -946,7 +946,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -956,11 +956,11 @@ class SMSCampaignsApi(object):
         """Update the campaign status  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sms_campaign_status(campaign_id, status, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sms_campaign_status(campaign_id, status, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param UpdateCampaignStatus status: Status of the campaign. (required)
         :return: None
@@ -968,7 +968,7 @@ class SMSCampaignsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_sms_campaign_status_with_http_info(campaign_id, status, **kwargs)  # noqa: E501
         else:
             (data) = self.update_sms_campaign_status_with_http_info(campaign_id, status, **kwargs)  # noqa: E501
@@ -978,11 +978,11 @@ class SMSCampaignsApi(object):
         """Update the campaign status  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_sms_campaign_status_with_http_info(campaign_id, status, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_sms_campaign_status_with_http_info(campaign_id, status, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int campaign_id: id of the campaign (required)
         :param UpdateCampaignStatus status: Status of the campaign. (required)
         :return: None
@@ -991,7 +991,7 @@ class SMSCampaignsApi(object):
         """
 
         all_params = ['campaign_id', 'status']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1051,7 +1051,7 @@ class SMSCampaignsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/smtp_api.py
+++ b/sib_api_v3_sdk/api/smtp_api.py
@@ -37,18 +37,18 @@ class SMTPApi(object):
         """Create an smtp template  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_smtp_template(smtp_template, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_smtp_template(smtp_template, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSmtpTemplate smtp_template: values to update in smtp template (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_smtp_template_with_http_info(smtp_template, **kwargs)  # noqa: E501
         else:
             (data) = self.create_smtp_template_with_http_info(smtp_template, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class SMTPApi(object):
         """Create an smtp template  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_smtp_template_with_http_info(smtp_template, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_smtp_template_with_http_info(smtp_template, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateSmtpTemplate smtp_template: values to update in smtp template (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class SMTPApi(object):
         """
 
         all_params = ['smtp_template']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -135,18 +135,18 @@ class SMTPApi(object):
 
         Delete hardbounces. To use carefully (e.g. in case of temporary ISP failures)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_hardbounces(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_hardbounces(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param DeleteHardbounces delete_hardbounces: values to delete hardbounces
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_hardbounces_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.delete_hardbounces_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class SMTPApi(object):
 
         Delete hardbounces. To use carefully (e.g. in case of temporary ISP failures)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_hardbounces_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_hardbounces_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param DeleteHardbounces delete_hardbounces: values to delete hardbounces
         :return: None
                  If the method is called asynchronously,
@@ -169,7 +169,7 @@ class SMTPApi(object):
         """
 
         all_params = ['delete_hardbounces']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -219,7 +219,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -229,18 +229,18 @@ class SMTPApi(object):
         """Delete an inactive smtp template  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_smtp_template(template_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_smtp_template(template_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_smtp_template_with_http_info(template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_smtp_template_with_http_info(template_id, **kwargs)  # noqa: E501
@@ -250,11 +250,11 @@ class SMTPApi(object):
         """Delete an inactive smtp template  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_smtp_template_with_http_info(template_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_smtp_template_with_http_info(template_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :return: None
                  If the method is called asynchronously,
@@ -262,7 +262,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -316,7 +316,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -326,11 +326,11 @@ class SMTPApi(object):
         """Get your SMTP activity aggregated over a period of time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aggregated_smtp_report(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_aggregated_smtp_report(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
         :param str end_date: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
         :param int days: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
@@ -340,7 +340,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_aggregated_smtp_report_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_aggregated_smtp_report_with_http_info(**kwargs)  # noqa: E501
@@ -350,11 +350,11 @@ class SMTPApi(object):
         """Get your SMTP activity aggregated over a period of time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aggregated_smtp_report_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_aggregated_smtp_report_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
         :param str end_date: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
         :param int days: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
@@ -365,7 +365,7 @@ class SMTPApi(object):
         """
 
         all_params = ['start_date', 'end_date', 'days', 'tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -421,7 +421,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='GetAggregatedReport',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -431,11 +431,11 @@ class SMTPApi(object):
         """Get all your SMTP activity (unaggregated events)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_event_report(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_event_report(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number limitation for the result returned
         :param int offset: Beginning point in the list to retrieve from.
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
@@ -451,7 +451,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_email_event_report_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_email_event_report_with_http_info(**kwargs)  # noqa: E501
@@ -461,11 +461,11 @@ class SMTPApi(object):
         """Get all your SMTP activity (unaggregated events)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_email_event_report_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_email_event_report_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number limitation for the result returned
         :param int offset: Beginning point in the list to retrieve from.
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
@@ -482,7 +482,7 @@ class SMTPApi(object):
         """
 
         all_params = ['limit', 'offset', 'start_date', 'end_date', 'days', 'email', 'event', 'tags', 'message_id', 'template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -552,7 +552,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='GetEmailEventReport',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -562,11 +562,11 @@ class SMTPApi(object):
         """Get your SMTP activity aggregated per day  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_report(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_report(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents returned per page
         :param int offset: Index of the first document on the page
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD)
@@ -578,7 +578,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_smtp_report_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_smtp_report_with_http_info(**kwargs)  # noqa: E501
@@ -588,11 +588,11 @@ class SMTPApi(object):
         """Get your SMTP activity aggregated per day  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_report_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_report_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents returned per page
         :param int offset: Index of the first document on the page
         :param str start_date: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD)
@@ -605,7 +605,7 @@ class SMTPApi(object):
         """
 
         all_params = ['limit', 'offset', 'start_date', 'end_date', 'days', 'tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -667,7 +667,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='GetReports',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -677,18 +677,18 @@ class SMTPApi(object):
         """Returns the template informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_template(template_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_template(template_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :return: GetSmtpTemplateOverview
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_smtp_template_with_http_info(template_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_smtp_template_with_http_info(template_id, **kwargs)  # noqa: E501
@@ -698,11 +698,11 @@ class SMTPApi(object):
         """Returns the template informations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_template_with_http_info(template_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_template_with_http_info(template_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :return: GetSmtpTemplateOverview
                  If the method is called asynchronously,
@@ -710,7 +710,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -764,7 +764,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='GetSmtpTemplateOverview',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -774,11 +774,11 @@ class SMTPApi(object):
         """Get the list of SMTP templates  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_templates(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_templates(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param bool template_status: Filter on the status of the template. Active = true, inactive = false
         :param int limit: Number of documents returned per page
         :param int offset: Index of the first document in the page
@@ -787,7 +787,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_smtp_templates_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_smtp_templates_with_http_info(**kwargs)  # noqa: E501
@@ -797,11 +797,11 @@ class SMTPApi(object):
         """Get the list of SMTP templates  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_smtp_templates_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_smtp_templates_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param bool template_status: Filter on the status of the template. Active = true, inactive = false
         :param int limit: Number of documents returned per page
         :param int offset: Index of the first document in the page
@@ -811,7 +811,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_status', 'limit', 'offset']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -867,7 +867,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='GetSmtpTemplates',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -878,11 +878,11 @@ class SMTPApi(object):
 
         This endpoint is deprecated. Prefer v3/smtp/email instead.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_template(template_id, send_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_template(template_id, send_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: Id of the template (required)
         :param SendEmail send_email: (required)
         :return: SendTemplateEmail
@@ -890,7 +890,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_template_with_http_info(template_id, send_email, **kwargs)  # noqa: E501
         else:
             (data) = self.send_template_with_http_info(template_id, send_email, **kwargs)  # noqa: E501
@@ -901,11 +901,11 @@ class SMTPApi(object):
 
         This endpoint is deprecated. Prefer v3/smtp/email instead.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_template_with_http_info(template_id, send_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_template_with_http_info(template_id, send_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: Id of the template (required)
         :param SendEmail send_email: (required)
         :return: SendTemplateEmail
@@ -914,7 +914,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_id', 'send_email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -974,7 +974,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='SendTemplateEmail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -984,11 +984,11 @@ class SMTPApi(object):
         """Send a template to your test list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_template(template_id, send_test_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_template(template_id, send_test_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: Id of the template (required)
         :param SendTestEmail send_test_email: (required)
         :return: None
@@ -996,7 +996,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_test_template_with_http_info(template_id, send_test_email, **kwargs)  # noqa: E501
         else:
             (data) = self.send_test_template_with_http_info(template_id, send_test_email, **kwargs)  # noqa: E501
@@ -1006,11 +1006,11 @@ class SMTPApi(object):
         """Send a template to your test list  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_test_template_with_http_info(template_id, send_test_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_test_template_with_http_info(template_id, send_test_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: Id of the template (required)
         :param SendTestEmail send_test_email: (required)
         :return: None
@@ -1019,7 +1019,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_id', 'send_test_email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1079,7 +1079,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1089,18 +1089,18 @@ class SMTPApi(object):
         """Send a transactional email  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_transac_email(send_smtp_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_transac_email(send_smtp_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param SendSmtpEmail send_smtp_email: Values to send a transactional email (required)
         :return: CreateSmtpEmail
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_transac_email_with_http_info(send_smtp_email, **kwargs)  # noqa: E501
         else:
             (data) = self.send_transac_email_with_http_info(send_smtp_email, **kwargs)  # noqa: E501
@@ -1110,11 +1110,11 @@ class SMTPApi(object):
         """Send a transactional email  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_transac_email_with_http_info(send_smtp_email, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_transac_email_with_http_info(send_smtp_email, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param SendSmtpEmail send_smtp_email: Values to send a transactional email (required)
         :return: CreateSmtpEmail
                  If the method is called asynchronously,
@@ -1122,7 +1122,7 @@ class SMTPApi(object):
         """
 
         all_params = ['send_smtp_email']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1176,7 +1176,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type='CreateSmtpEmail',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1186,11 +1186,11 @@ class SMTPApi(object):
         """Updates an smtp templates  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_smtp_template(template_id, smtp_template, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_smtp_template(template_id, smtp_template, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :param UpdateSmtpTemplate smtp_template: values to update in smtp template (required)
         :return: None
@@ -1198,7 +1198,7 @@ class SMTPApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_smtp_template_with_http_info(template_id, smtp_template, **kwargs)  # noqa: E501
         else:
             (data) = self.update_smtp_template_with_http_info(template_id, smtp_template, **kwargs)  # noqa: E501
@@ -1208,11 +1208,11 @@ class SMTPApi(object):
         """Updates an smtp templates  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_smtp_template_with_http_info(template_id, smtp_template, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_smtp_template_with_http_info(template_id, smtp_template, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int template_id: id of the template (required)
         :param UpdateSmtpTemplate smtp_template: values to update in smtp template (required)
         :return: None
@@ -1221,7 +1221,7 @@ class SMTPApi(object):
         """
 
         all_params = ['template_id', 'smtp_template']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1281,7 +1281,7 @@ class SMTPApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/transactional_sms_api.py
+++ b/sib_api_v3_sdk/api/transactional_sms_api.py
@@ -37,11 +37,11 @@ class TransactionalSMSApi(object):
         """Get all the SMS activity (unaggregated events)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_events(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_events(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
@@ -55,7 +55,7 @@ class TransactionalSMSApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_sms_events_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_sms_events_with_http_info(**kwargs)  # noqa: E501
@@ -65,11 +65,11 @@ class TransactionalSMSApi(object):
         """Get all the SMS activity (unaggregated events)  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_sms_events_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_sms_events_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int limit: Number of documents per page
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
@@ -84,7 +84,7 @@ class TransactionalSMSApi(object):
         """
 
         all_params = ['limit', 'start_date', 'end_date', 'offset', 'days', 'phone_number', 'event', 'tags']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -150,7 +150,7 @@ class TransactionalSMSApi(object):
             files=local_var_files,
             response_type='GetSmsEventReport',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -160,11 +160,11 @@ class TransactionalSMSApi(object):
         """Get your SMS activity aggregated over a period of time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_transac_aggregated_sms_report(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_transac_aggregated_sms_report(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
         :param int days: Number of days in the past including today (positive integer). Not compatible with startDate and endDate
@@ -174,7 +174,7 @@ class TransactionalSMSApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_transac_aggregated_sms_report_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_transac_aggregated_sms_report_with_http_info(**kwargs)  # noqa: E501
@@ -184,11 +184,11 @@ class TransactionalSMSApi(object):
         """Get your SMS activity aggregated over a period of time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_transac_aggregated_sms_report_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_transac_aggregated_sms_report_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
         :param int days: Number of days in the past including today (positive integer). Not compatible with startDate and endDate
@@ -199,7 +199,7 @@ class TransactionalSMSApi(object):
         """
 
         all_params = ['start_date', 'end_date', 'days', 'tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -255,7 +255,7 @@ class TransactionalSMSApi(object):
             files=local_var_files,
             response_type='GetTransacAggregatedSmsReport',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -265,11 +265,11 @@ class TransactionalSMSApi(object):
         """Get your SMS activity aggregated per day  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_transac_sms_report(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_transac_sms_report(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
         :param int days: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
@@ -279,7 +279,7 @@ class TransactionalSMSApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_transac_sms_report_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_transac_sms_report_with_http_info(**kwargs)  # noqa: E501
@@ -289,11 +289,11 @@ class TransactionalSMSApi(object):
         """Get your SMS activity aggregated per day  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_transac_sms_report_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_transac_sms_report_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str start_date: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
         :param str end_date: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
         :param int days: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
@@ -304,7 +304,7 @@ class TransactionalSMSApi(object):
         """
 
         all_params = ['start_date', 'end_date', 'days', 'tag']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -360,7 +360,7 @@ class TransactionalSMSApi(object):
             files=local_var_files,
             response_type='GetTransacSmsReport',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -370,18 +370,18 @@ class TransactionalSMSApi(object):
         """Send the SMS campaign to the specified mobile number  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_transac_sms(send_transac_sms, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_transac_sms(send_transac_sms, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param SendTransacSms send_transac_sms: Values to send a transactional SMS (required)
         :return: SendSms
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.send_transac_sms_with_http_info(send_transac_sms, **kwargs)  # noqa: E501
         else:
             (data) = self.send_transac_sms_with_http_info(send_transac_sms, **kwargs)  # noqa: E501
@@ -391,11 +391,11 @@ class TransactionalSMSApi(object):
         """Send the SMS campaign to the specified mobile number  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.send_transac_sms_with_http_info(send_transac_sms, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.send_transac_sms_with_http_info(send_transac_sms, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param SendTransacSms send_transac_sms: Values to send a transactional SMS (required)
         :return: SendSms
                  If the method is called asynchronously,
@@ -403,7 +403,7 @@ class TransactionalSMSApi(object):
         """
 
         all_params = ['send_transac_sms']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -457,7 +457,7 @@ class TransactionalSMSApi(object):
             files=local_var_files,
             response_type='SendSms',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api/webhooks_api.py
+++ b/sib_api_v3_sdk/api/webhooks_api.py
@@ -37,18 +37,18 @@ class WebhooksApi(object):
         """Create a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_webhook(create_webhook, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_webhook(create_webhook, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateWebhook create_webhook: Values to create a webhook (required)
         :return: CreateModel
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.create_webhook_with_http_info(create_webhook, **kwargs)  # noqa: E501
         else:
             (data) = self.create_webhook_with_http_info(create_webhook, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class WebhooksApi(object):
         """Create a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_webhook_with_http_info(create_webhook, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.create_webhook_with_http_info(create_webhook, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param CreateWebhook create_webhook: Values to create a webhook (required)
         :return: CreateModel
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['create_webhook']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='CreateModel',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,18 +134,18 @@ class WebhooksApi(object):
         """Delete a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_webhook(webhook_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_webhook(webhook_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.delete_webhook_with_http_info(webhook_id, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_webhook_with_http_info(webhook_id, **kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class WebhooksApi(object):
         """Delete a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_webhook_with_http_info(webhook_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.delete_webhook_with_http_info(webhook_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :return: None
                  If the method is called asynchronously,
@@ -167,7 +167,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['webhook_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -231,18 +231,18 @@ class WebhooksApi(object):
         """Get a webhook details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_webhook(webhook_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_webhook(webhook_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :return: GetWebhook
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_webhook_with_http_info(webhook_id, **kwargs)  # noqa: E501
         else:
             (data) = self.get_webhook_with_http_info(webhook_id, **kwargs)  # noqa: E501
@@ -252,11 +252,11 @@ class WebhooksApi(object):
         """Get a webhook details  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_webhook_with_http_info(webhook_id, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_webhook_with_http_info(webhook_id, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :return: GetWebhook
                  If the method is called asynchronously,
@@ -264,7 +264,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['webhook_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -318,7 +318,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='GetWebhook',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -328,18 +328,18 @@ class WebhooksApi(object):
         """Get all webhooks  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_webhooks(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_webhooks(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str type: Filter on webhook type
         :return: GetWebhooks
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.get_webhooks_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_webhooks_with_http_info(**kwargs)  # noqa: E501
@@ -349,11 +349,11 @@ class WebhooksApi(object):
         """Get all webhooks  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_webhooks_with_http_info(async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.get_webhooks_with_http_info(asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param str type: Filter on webhook type
         :return: GetWebhooks
                  If the method is called asynchronously,
@@ -361,7 +361,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['type']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -411,7 +411,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type='GetWebhooks',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -421,11 +421,11 @@ class WebhooksApi(object):
         """Update a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_webhook(webhook_id, update_webhook, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_webhook(webhook_id, update_webhook, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :param UpdateWebhook update_webhook: Values to update a webhook (required)
         :return: None
@@ -433,7 +433,7 @@ class WebhooksApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('asynchronous'):
             return self.update_webhook_with_http_info(webhook_id, update_webhook, **kwargs)  # noqa: E501
         else:
             (data) = self.update_webhook_with_http_info(webhook_id, update_webhook, **kwargs)  # noqa: E501
@@ -443,11 +443,11 @@ class WebhooksApi(object):
         """Update a webhook  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.update_webhook_with_http_info(webhook_id, update_webhook, async=True)
+        asynchronous HTTP request, please pass asynchronous=True
+        >>> thread = api.update_webhook_with_http_info(webhook_id, update_webhook, asynchronous=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param asynchronous bool
         :param int webhook_id: Id of the webhook (required)
         :param UpdateWebhook update_webhook: Values to update a webhook (required)
         :return: None
@@ -456,7 +456,7 @@ class WebhooksApi(object):
         """
 
         all_params = ['webhook_id', 'update_webhook']  # noqa: E501
-        all_params.append('async')
+        all_params.append('asynchronous')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -516,7 +516,7 @@ class WebhooksApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronous=params.get('asynchronous'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sib_api_v3_sdk/api_client.py
+++ b/sib_api_v3_sdk/api_client.py
@@ -274,12 +274,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, asynchronous=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an asynchronous request, set the asynchronous parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -294,7 +294,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param asynchronous bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -307,13 +307,13 @@ class ApiClient(object):
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
         :return:
-            If async parameter is True,
+            If asynchronous parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter asynchronous is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not asynchronous:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,


### PR DESCRIPTION
Fix compatibility with python 3.7
Not sure everything is fixed, I simply renamed async => asynchronous where needed
Tried on GAE and locally, for sending templates, and it works