### PR TITLE
Fix bug in send_smtp_email.py

### DIFF
--- a/sib_api_v3_sdk/models/send_smtp_email.py
+++ b/sib_api_v3_sdk/models/send_smtp_email.py
@@ -82,7 +82,8 @@ class SendSmtpEmail(object):
 
         if sender is not None:
             self.sender = sender
-        self.to = to
+        if to is not None:
+            self.to = to
         if bcc is not None:
             self.bcc = bcc
         if cc is not None:


### PR DESCRIPTION
Resolves an issue encountered with the examples.

```
to = [{"email": "confidential@domain.fr"}]
```

Before this fix:

```
  File "/home/ubuntu/.local/lib/python3.6/site-packages/sib_api_v3_sdk/models/send_smtp_email.py", line 85, in __init__
    self.to = to
  File "/home/ubuntu/.local/lib/python3.6/site-packages/sib_api_v3_sdk/models/send_smtp_email.py", line 151, in to
    raise ValueError("Invalid value for `to`, must not be `None`")  # noqa: E501
ValueError: Invalid value for `to`, must not be `None`
```
=> It does not work

After this fix:

```
{'message_id': '<CONFIDENTIAL@smtp-relay.mailin.fr>'}
```

=> It works